### PR TITLE
Update python version and required packages

### DIFF
--- a/create_env.sh
+++ b/create_env.sh
@@ -3,7 +3,7 @@
 # 1. Create the speechain environment if there is no environment named speechain
 
 # Set the python version, if use other than 3.9, modify environment.yaml
-PYTHON_VERSION=3.8
+PYTHON_VERSION=3.9
 echo "Installing speechain env using Python version: $PYTHON_VERSION"
 
 speechain_envir=$(conda env list | grep speechain)

--- a/datasets/README.md
+++ b/datasets/README.md
@@ -1,6 +1,6 @@
 # Datasets (Directory)
 
-The `dataset` folder contains all the available datasets in this toolkit. 
+The `datasets` folder contains all the available datasets in this toolkit. 
 Each dataset corresponds to a sub-folder and has a uniform file system. 
 You can easily dump your target dataset to your machine by following the instructions below. 
 If you want to contribute a new dataset, we would appreciate it if you could follow our file systems and metadata formats.
@@ -17,7 +17,7 @@ If you want to contribute a new dataset, we would appreciate it if you could fol
     5. [idx2text](https://github.com/bagustris/SpeeChain/tree/main/datasets#idx2text)
     6. [idx2spk](https://github.com/bagustris/SpeeChain/tree/main/datasets#idx2spk)
     7. [idx2spk_feat](https://github.com/bagustris/SpeeChain/tree/main/datasets#idx2spk_feat)
-    8. [spk_list](https://github.com/bagustris/SpeeChain/tree/main/datasets#spk_list)
+    8. [spk_list](https://github.com/bagustris/SpeeChain/tree/main/dat/home/bagustris/github/speechain/asets#spk_list)
     9. [idx2gen](https://github.com/bagustris/SpeeChain/tree/main/datasets#idx2gen)
 3. [**How to Dump a Dataset on your Machine**](https://github.com/bagustris/SpeeChain/tree/main/datasets#how-to-dump-a-dataset-on-your-machine)
 4. [**How to Extract Speaker Embedding by my own model**](https://github.com/bagustris/SpeeChain/tree/main/datasets#how-to-extract-speaker-embedding-by-my-own-model)

--- a/datasets/librispeech/run.sh
+++ b/datasets/librispeech/run.sh
@@ -1,12 +1,14 @@
-#  Author: Heli Qi
-#  Affiliation: NAIST
-#  Date: 2022.11
+# Author: Heli Qi
+# Affiliation: NAIST
+# Date: 2022.11
 
 # 2024.11.26: @bagustris added subsets of dev-clean-2, train-clean-5
 
 if [ -z "${SPEECHAIN_ROOT}" ];then
   echo "Cannot find environmental variable SPEECHAIN_ROOT.
-  Please move to the root path of the toolkit and run envir_preparation.sh there!"
+  Please set the environment variables
+  $ export SPEECHAIN_ROOT=/your/path/to/speechain
+  $ export SPEECHAIN_PYTHON=$(which python)"
   exit 1
 fi
 
@@ -75,7 +77,8 @@ txt_format=no-punc
 # LibriSpeech-specific arguments
 # which part of LibriSpeech corpus you want to dump
 # 5: train-clean-5; 100: train-clean-100; 460: train-clean-100 + train-clean-360; 960: train-clean-100 + train-clean-360 + train-other-500
-# dev-clean, dev-clean-2, dev-other, test-clean, test-other will be downloaded regardless of your input dump_part
+# dev-clean, dev-other, test-clean, test-other will be downloaded if your input not 5
+# dev-clean-2 and test-clean will be downloaded if your input is 5
 dump_part=5
 
 
@@ -234,9 +237,16 @@ case "${dump_part}" in
     exit 1
 esac
 
-# attach dev and test sets to 'subsets' arguments for any input dump_part
-subsets="${subsets} dev-clean dev-clean-2 dev-other test-clean test-other"
-subsets_args="${subsets_args}${separator}dev-clean${separator}dev-clean-2${separator}dev-other${separator}test-clean${separator}test-other"
+# attach dev and test sets to 'subsets' arguments based on dump_part
+if [ ${dump_part} == 5 ]; then
+  # For dump_part=5, only download train-clean-5, dev-clean-2, and test-clean
+  subsets="${subsets} dev-clean-2 test-clean"
+  subsets_args="${subsets_args}${separator}dev-clean-2${separator}test-clean"
+else
+  # For other dump_parts, download full dev and test sets
+  subsets="${subsets} dev-clean dev-clean-2 dev-other test-clean test-other"
+  subsets_args="${subsets_args}${separator}dev-clean${separator}dev-clean-2${separator}dev-other${separator}test-clean${separator}test-other"
+fi
 # enter extra arguments for vocab_generator.py
 vocab_generate_args=
 # number of tokens in the vocabulary

--- a/recipes/asr/README.md
+++ b/recipes/asr/README.md
@@ -155,22 +155,22 @@ Before training an ASR model, ensure that your target datasets are dumped by the
 More details on how to dump a dataset can be found [here](https://github.com/bagustris/SpeeChain/tree/main/datasets#how-to-dump-a-dataset-on-your-machine).
 
 ### Use an existing dataset with a pre-tuned configuration
-1. locate a _.yaml_ configuration file in `${SPEECHAIN_ROOT}/recipes/asr`. 
-   Suppose we want to train an ASR model by the configuration `${SPEECHAIN_ROOT}/recipes/asr/librispeech/train-960/exp_cfg/960-bpe5k_transformer-wide_ctc_perturb.yaml`.
+1. Locate a _.yaml_ configuration file in `${SPEECHAIN_ROOT}/recipes/asr`. 
+   Suppose we want to train an ASR model by the configuration `${SPEECHAIN_ROOT}/recipes/asr/librispeech/train-clean-5/exp_cfg/5-bpe1k_conformer-small_lr2e-3.yaml`.
 
 2. Train and evaluate the ASR model on your target training set
    
    ```bash
    cd ${SPEECHAIN_ROOT}/recipes/asr/librispeech/train-960
-   bash run.sh --exp_cfg 960-bpe5k_transformer-wide_ctc_perturb (--ngpu x --gpus x,x)
+   bash run.sh --exp_cfg 5-bpe1k_conformer-small_lr2e-3 (--ngpu x --gpus x,x)
    ```
    **Note:**   
       1. Review the comments on the top of the configuration file to ensure that your computational resources fit the configuration before training the model.  
       If your resources do not match the configuration, adjust it by `--ngpu` and `--gpus` to match your available GPU memory.  
       2. To save the experimental results outside the toolkit folder `${SPEECHAIN_ROOT}`, 
          specify your desired location by appending `--train_result_path {your-target-path}` to `bash run.sh`.  
-         In this example, `bash run.sh --exp_cfg 960-bpe5k_transformer-wide_ctc_perturb --train_result_path /a/b/c`
-         will save results to `/a/b/c/960-bpe5k_transformer-wide_ctc_perturb`.
+         In this example, `bash run.sh --exp_cfg 5-bpe1k_conformer-small_lr2e-3 --train_result_path /a/b/c`
+         will save results to `/a/b/c/5-bpe1k_conformer-small_lr2e-3`.
 
 ### Creating a new configuration for a non-existing dataset  
 

--- a/recipes/asr/librispeech/train-clean-5/exp_cfg/5-bpe1k_conformer-small_lr2e-3.yaml
+++ b/recipes/asr/librispeech/train-clean-5/exp_cfg/5-bpe1k_conformer-small_lr2e-3.yaml
@@ -76,6 +76,7 @@ visual_snapshot_interval: 5
 
 # testing-related
 test: False
+test_model: 10_valid_accuracy_average
 
 # This argument is shared by data_cfg and train_cfg
 data_root: !ref <dataset_path>/<dataset>/data
@@ -127,6 +128,22 @@ data_cfg:
 
       shuffle: False
       data_len: !ref <data_root>/<wav_format>/<valid_set>/idx2wav_len
+
+  test:
+    test-clean:
+      type: abs.Iterator
+      conf:
+        dataset_type: speech_text.SpeechTextDataset
+        dataset_conf:
+          main_data:
+            feat: !ref <data_root>/<wav_format>/test-clean/idx2wav
+            text: !ref <data_root>/<wav_format>/test-clean/idx2<txt_format>_text
+
+        data_len: !ref <data_root>/<wav_format>/test-clean/idx2wav_len
+        shuffle: False
+        group_info:
+          speaker: !ref <data_root>/<wav_format>/test-clean/idx2spk
+          gender: !ref <data_root>/<wav_format>/test-clean/idx2gen
 
 # Model Construction Configuration #
 ####################################

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-editdistance==0.6.0
+edit-distance>=0.6.0
 g2p_en==2.1.0
 GPUtil==1.4.0
 h5py==3.1.0


### PR DESCRIPTION
## Summary by Sourcery

Update LibriSpeech dataset dumping, training configuration, and documentation to better support the train-clean-5 setup while aligning environment and dependency requirements.

New Features:
- Add test-clean evaluation configuration to the train-clean-5 ASR experiment config.

Bug Fixes:
- Correct dataset README references to the datasets folder name and fix the spk_list documentation link.

Enhancements:
- Adjust LibriSpeech dump script to download different dev/test subsets depending on the selected dump partition.
- Clarify environment variable setup instructions in the LibriSpeech run script.
- Update ASR README example to use the train-clean-5 configuration and corresponding run command.

Build:
- Bump the default Python version used in the environment creation script from 3.8 to 3.9.
- Relax the editdistance dependency constraint and fix its name in requirements.txt.