### PR TITLE
Add Albanian ASR and character LM recipes

### DIFF
--- a/recipes/asr/albanian/README.md
+++ b/recipes/asr/albanian/README.md
@@ -1,0 +1,126 @@
+# Albanian ASR with Speechain
+
+This recipe contains a Speechain-based ASR setup for low-resource Albanian speech recognition.
+
+## Goal
+
+The goal is to build and improve a from-scratch ASR baseline for Albanian using Speechain.
+
+The current setup focuses on:
+- character-level ASR
+- external language model decoding
+- CTC/LM weight tuning
+
+## Dataset
+
+The experiments are based on Mozilla Common Voice Albanian.
+
+Prepared splits:
+- Train: 2,633 utterances
+- Dev: 1,795 utterances
+- Test: 1,908 utterances
+
+The dataset itself is not included in this repository.
+
+Local data root used during the experiments:
+/home/ldap-users-2/veton-lu/data/albanian_asr
+
+## ASR Model
+
+Final ASR setup:
+- Model: Speechain ARASR
+- Encoder: Conformer
+- Decoder: Transformer
+- Tokenizer: character-level tokenizer
+- Output vocabulary: 34 tokens
+- Parameters: approximately 4.74M
+
+Main ASR config:
+exp_cfg/cv_sq_full_char_sp_ctc05_do02_acc2_e100.yaml
+
+## Training Setup
+
+Improved ASR training configuration:
+- max_epochs: 100
+- early_stopping_patience: 15
+- stopped_epoch: 75
+- batch_len: 3.0e5
+- accum_grad: 2
+- training_ctc_weight: 0.5
+- label_smoothing: 0.05
+- dropout: 0.2
+- warmup_steps: 2000
+- speed_perturbation: enabled
+
+Important note:
+The training CTC weight was 0.5.
+The CTC weights 0.3 and 0.4 were only used during offline decoding sweeps.
+
+## External Language Model
+
+The external LM was a character-level Transformer LM trained from scratch in Speechain.
+
+LM experiment name:
+wiki_char_transformer
+
+LM recipe:
+recipes/lm/albanian/wiki_char_lm_text
+
+The LM was trained using cleaned Albanian Wikipedia text and Common Voice training transcripts.
+
+The LM was used only during beam-search decoding, not during ASR training.
+
+## Final Results
+
+### Key result
+
+The best WER was achieved with the final CTC/LM decoding sweep.
+
+* Best WER setup: `ctc_weight = 0.3`, `lm_weight = 1.4`
+* CER: 35.36%
+* WER: 63.82%
+
+### Performance progression
+
+| Step | System                              |    CER |    WER |
+| ---: | ----------------------------------- | -----: | -----: |
+|    1 | First ASR baseline without LM       | 46.51% | 92.79% |
+|    2 | First ASR baseline with external LM | 43.60% | 83.92% |
+|    3 | Improved ASR with external LM       | 35.14% | 64.40% |
+|    4 | Final CTC/LM sweep                  | 35.36% | 63.82% |
+
+### Overall improvement
+
+Compared to the first ASR baseline without LM:
+
+* CER improved from 46.51% to 35.36%
+* CER reduction: 11.15 percentage points
+* WER improved from 92.79% to 63.82%
+* WER reduction: 28.97 percentage points
+
+### Best decoding configurations
+
+| Objective | ctc_weight | lm_weight |    CER |    WER |
+| --------- | ---------: | --------: | -----: | -----: |
+| Best WER  |        0.3 |       1.4 | 35.36% | 63.82% |
+| Best CER  |        0.4 |       1.2 | 34.90% | 64.85% |
+
+
+## Qualitative Example
+
+Reference:
+ky fshat është i izoluar nga bota është i harruar
+
+Hypothesis:
+ky fshat dhe shitën guara porta është i hartuar
+
+Utterance-level CER: 35.00%
+Utterance-level WER: 60.00%
+
+This example illustrates that the model can recognize parts of the utterance correctly, but still produces plausible yet incorrect Albanian word sequences during LM-based decoding.
+
+## Notes
+
+The model is trained from scratch and remains limited by the small amount of available Albanian speech data.
+
+Future work should compare this Speechain baseline against pretrained multilingual ASR models such as Whisper, MMS, and XLS-R.

--- a/recipes/asr/albanian/README.md
+++ b/recipes/asr/albanian/README.md
@@ -22,8 +22,8 @@ Prepared splits:
 
 The dataset itself is not included in this repository.
 
-Local data root used during the experiments:
-/home/ldap-users-2/veton-lu/data/albanian_asr
+Recommended data root directory:
+datasets/albanian_asr
 
 ## ASR Model
 

--- a/recipes/asr/albanian/data_cfg/test_dev-clean.yaml
+++ b/recipes/asr/albanian/data_cfg/test_dev-clean.yaml
@@ -1,0 +1,40 @@
+##############################################################################
+# Testing: dev-clean of LibriSpeech
+# Authors: Heli Qi
+# Description: This configuration is used to replace data_cfg in exp_cfg for tuning the inference hyperparamters on dev-clean-2
+# ############################################################################
+
+
+###################################
+# Experiment Parameters and setup #
+###################################
+# if your dumped dataset is outside the toolkit folder, please change dataset_path. There should be a folder named 'libritts' in dataset_path
+dataset_path: datasets/
+valid_dset: &valid_dset dev-clean-2
+dataset: librispeech
+
+wav_format: wav
+txt_format: no-punc
+
+
+
+##############################
+# Data Loading Configuration #
+##############################
+data_root: !ref <dataset_path>/<dataset>/data
+# Note: there must be a blank between the anchor '*valid_dset' and the colon ':'
+test:
+    *valid_dset :
+        type: abs.Iterator
+        conf:
+            dataset_type: speech_text.SpeechTextDataset
+            dataset_conf:
+                main_data:
+                    feat: !ref <data_root>/<wav_format>/<valid_dset>/idx2wav
+                    text: !ref <data_root>/<wav_format>/<valid_dset>/idx2<txt_format>_text
+
+            shuffle: False
+            data_len: !ref <data_root>/<wav_format>/<valid_dset>/idx2wav_len
+            group_info:
+                speaker: !ref <data_root>/<wav_format>/<valid_dset>/idx2spk
+                gender: !ref <data_root>/<wav_format>/<valid_dset>/idx2gen

--- a/recipes/asr/albanian/data_cfg/test_dev-clean.yaml
+++ b/recipes/asr/albanian/data_cfg/test_dev-clean.yaml
@@ -1,17 +1,15 @@
-##############################################################################
-# Testing: dev-clean of LibriSpeech
-# Authors: Heli Qi
-# Description: This configuration is used to replace data_cfg in exp_cfg for tuning the inference hyperparamters on dev-clean-2
-# ############################################################################
+################################################################################
+# Testing: dev_full of Albanian ASR
+# Description: This configuration is used to evaluate or tune inference hyperparameters on the Albanian dev split.
+################################################################################
 
 
 ###################################
 # Experiment Parameters and setup #
 ###################################
-# if your dumped dataset is outside the toolkit folder, please change dataset_path. There should be a folder named 'libritts' in dataset_path
 dataset_path: datasets/
-valid_dset: &valid_dset dev-clean-2
-dataset: librispeech
+valid_dset: &valid_dset dev_full
+dataset: albanian_asr
 
 wav_format: wav
 txt_format: no-punc
@@ -22,7 +20,7 @@ txt_format: no-punc
 # Data Loading Configuration #
 ##############################
 data_root: !ref <dataset_path>/<dataset>/data
-# Note: there must be a blank between the anchor '*valid_dset' and the colon ':'
+
 test:
     *valid_dset :
         type: abs.Iterator

--- a/recipes/asr/albanian/data_cfg/test_test-clean.yaml
+++ b/recipes/asr/albanian/data_cfg/test_test-clean.yaml
@@ -1,0 +1,40 @@
+##############################################################################
+# Testing: dev-clean of LibriSpeech
+# Authors: Heli Qi
+# Description: This configuration is used to replace data_cfg in exp_cfg for tuning the inference hyperparamters on dev-clean
+# ############################################################################
+
+
+###################################
+# Experiment Parameters and setup #
+###################################
+# if your dumped dataset is outside the toolkit folder, please change dataset_path. There should be a folder named 'libritts' in dataset_path
+dataset_path: datasets/
+dataset: librispeech
+valid_dset: &valid_dset test-clean
+
+wav_format: wav
+txt_format: no-punc
+
+
+
+##############################
+# Data Loading Configuration #
+##############################
+data_root: !ref <dataset_path>/<dataset>/data
+# Note: there must be a blank between the anchor '*valid_dset' and the colon ':'
+test:
+    *valid_dset :
+        type: abs.Iterator
+        conf:
+            dataset_type: speech_text.SpeechTextDataset
+            dataset_conf:
+                main_data:
+                    feat: !ref <data_root>/<wav_format>/<valid_dset>/idx2wav
+                    text: !ref <data_root>/<wav_format>/<valid_dset>/idx2<txt_format>_text
+
+            shuffle: False
+            data_len: !ref <data_root>/<wav_format>/<valid_dset>/idx2wav_len
+            group_info:
+                speaker: !ref <data_root>/<wav_format>/<valid_dset>/idx2spk
+                gender: !ref <data_root>/<wav_format>/<valid_dset>/idx2gen

--- a/recipes/asr/albanian/data_cfg/test_test-clean.yaml
+++ b/recipes/asr/albanian/data_cfg/test_test-clean.yaml
@@ -1,17 +1,15 @@
-##############################################################################
-# Testing: dev-clean of LibriSpeech
-# Authors: Heli Qi
-# Description: This configuration is used to replace data_cfg in exp_cfg for tuning the inference hyperparamters on dev-clean
-# ############################################################################
+################################################################################
+# Testing: test_full of Albanian ASR
+# Description: This configuration is used to evaluate the final ASR model on the Albanian test split.
+################################################################################
 
 
 ###################################
 # Experiment Parameters and setup #
 ###################################
-# if your dumped dataset is outside the toolkit folder, please change dataset_path. There should be a folder named 'libritts' in dataset_path
 dataset_path: datasets/
-dataset: librispeech
-valid_dset: &valid_dset test-clean
+dataset: albanian_asr
+valid_dset: &valid_dset test_full
 
 wav_format: wav
 txt_format: no-punc

--- a/recipes/asr/albanian/exp_cfg/cv_sq_full_char_sp_ctc05_do02_acc2_e100.yaml
+++ b/recipes/asr/albanian/exp_cfg/cv_sq_full_char_sp_ctc05_do02_acc2_e100.yaml
@@ -1,0 +1,216 @@
+
+###################################
+# Experiment Parameters and setup #
+###################################
+# dataset-related
+dataset_path: /home/ldap-users-2/veton-lu/data
+dataset: albanian_asr
+train_set: train_full
+valid_set: dev_full
+
+# waveform-related
+wav_format: meta
+sample_rate: 16000
+
+# tokenizer-related
+txt_format: no-punc
+vocab_subset: train_full
+token_type: char
+token_num: char
+
+# batch-related
+batch_len: 3.0e5
+
+# model-related
+ctc_weight: 0.5
+label_smoothing: 0.05
+d_model: 128
+num_heads: 4
+fdfwd_dim: 512
+dropout: 0.2
+
+# optimizer-related
+warmup_steps: 2000
+
+# running-related
+seed: 0
+num_workers: 1
+pin_memory: False
+non_blocking: False
+
+# gradient-related
+accum_grad: 2
+ft_factor: 1.0
+grad_clip: 5.0
+
+# multi-GPU-related
+ngpu: 1 # please change ngpu based on the situation of your machine
+gpus: null # null means the GPUs with the largest free memory will be
+# training-related
+train: True
+best_model_selection: !tuple (valid, accuracy, max, 10)
+early_stopping_patience: 15
+num_epochs: 100
+
+# snapshot-related
+visual_snapshot_number: 3
+visual_snapshot_interval: 5
+
+# testing-related
+test: False
+test_model: 10_valid_accuracy_average
+
+# This argument is shared by data_cfg and train_cfg
+data_root: /home/ldap-users-2/veton-lu/data/albanian_asr
+
+
+
+#################################
+# Model Inference Configuration #
+#################################
+infer_cfg:
+  shared_args:
+    beam_size: 16
+  exclu_args:
+    - ctc_weight: 0.2
+      lm_weight: 0.1
+    - ctc_weight: 0.2
+      lm_weight: 0.2
+    - ctc_weight: 0.2
+      lm_weight: 0.4
+    - ctc_weight: 0.2
+      lm_weight: 0.6
+
+
+# Data Loading Configuration
+data_cfg:
+  train:
+    type: block.BlockIterator
+    conf:
+      dataset_type: speech_text.SpeechTextDataset
+      dataset_conf:
+        main_data:
+          feat: !ref <data_root>/<wav_format>/<train_set>/idx2wav
+          text: !ref <data_root>/<wav_format>/<train_set>/idx2<txt_format>_text
+        use_speed_perturb: True
+
+      data_len: !ref <data_root>/<wav_format>/<train_set>/idx2wav_len
+      shuffle: True
+      is_descending: True
+      batch_len: !ref <batch_len>
+
+  valid:
+    type: abs.Iterator
+    conf:
+      dataset_type: speech_text.SpeechTextDataset
+      dataset_conf:
+        main_data:
+          feat: !ref <data_root>/<wav_format>/<valid_set>/idx2wav
+          text: !ref <data_root>/<wav_format>/<valid_set>/idx2<txt_format>_text
+
+      shuffle: False
+      data_len: !ref <data_root>/<wav_format>/<valid_set>/idx2wav_len
+
+  test:
+    test_full:
+      type: abs.Iterator
+      conf:
+        dataset_type: speech_text.SpeechTextDataset
+        dataset_conf:
+          main_data:
+            feat: !ref <data_root>/<wav_format>/test_full/idx2wav
+            text: !ref <data_root>/<wav_format>/test_full/idx2<txt_format>_text
+
+        data_len: !ref <data_root>/<wav_format>/test_full/idx2wav_len
+        shuffle: False
+
+
+# Model Construction Configuration
+train_cfg:
+  model:
+    model_type: ar_asr.ARASR
+    model_conf:
+      customize_conf:
+        ctc_weight: !ref <ctc_weight>
+        token_type: !ref <token_type>
+        token_path: !ref <data_root>/<token_type>/<vocab_subset>/<token_num>/<txt_format>
+
+    module_conf:
+      frontend:
+        type: frontend.speech2mel.Speech2MelSpec
+        conf:
+          sr: !ref <sample_rate>
+          preemphasis: 0.97
+          hop_length: 0.010
+          win_length: 0.025
+          n_mels: 80
+
+      normalize:
+        norm_type: utterance
+        mean_norm: True
+        std_norm: True
+
+      enc_prenet:
+        type: prenet.conv2d.Conv2dPrenet
+        conf:
+          conv_dims:
+            - !ref <d_model>
+            - !ref <d_model>
+          conv_kernel: 3
+          conv_stride: 2
+          conv_batchnorm: true
+          conv_activation: LeakyReLU
+          lnr_dims: !ref <d_model>
+
+      encoder:
+        type: conformer.encoder.ConformerEncoder
+        conf:
+          posenc_dropout: !ref <dropout>
+          emb_scale: False
+          d_model: !ref <d_model>
+          num_heads: !ref <num_heads>
+          num_layers: 8
+          att_dropout: !ref <dropout>
+          fdfwd_dim: !ref <fdfwd_dim>
+          fdfwd_activation: GELU
+          fdfwd_dropout: !ref <dropout>
+          res_dropout: !ref <dropout>
+          layernorm_first: true
+
+      dec_emb:
+        type: prenet.embed.EmbedPrenet
+        conf:
+          embedding_dim: !ref <d_model>
+
+      decoder:
+        type: transformer.decoder.TransformerDecoder
+        conf:
+          posenc_dropout: !ref <dropout>
+          posenc_scale: false
+          emb_layernorm: true
+          emb_scale: false
+          d_model: !ref <d_model>
+          num_heads: !ref <num_heads>
+          num_layers: 4
+          att_dropout: !ref <dropout>
+          fdfwd_dim: !ref <fdfwd_dim>
+          fdfwd_activation: GELU
+          fdfwd_dropout: !ref <dropout>
+          res_dropout: !ref <dropout>
+          layernorm_first: true
+
+    criterion_conf:
+      ce_loss:
+        label_smoothing: !ref <label_smoothing>
+
+  optim_sches:
+    type: noam.Noamlr
+    conf:
+      optim_type: Adam
+      optim_conf:
+        lr: 0.002
+        betas:
+          - 0.9
+          - 0.98
+        eps: 1.0e-9
+      warmup_steps: !ref <warmup_steps>

--- a/recipes/asr/albanian/exp_cfg/cv_sq_full_char_sp_ctc05_do02_acc2_e100.yaml
+++ b/recipes/asr/albanian/exp_cfg/cv_sq_full_char_sp_ctc05_do02_acc2_e100.yaml
@@ -3,7 +3,7 @@
 # Experiment Parameters and setup #
 ###################################
 # dataset-related
-dataset_path: /home/ldap-users-2/veton-lu/data
+dataset_path: datasets
 dataset: albanian_asr
 train_set: train_full
 valid_set: dev_full
@@ -61,7 +61,7 @@ test: False
 test_model: 10_valid_accuracy_average
 
 # This argument is shared by data_cfg and train_cfg
-data_root: /home/ldap-users-2/veton-lu/data/albanian_asr
+data_root: !ref <dataset_path>/<dataset>
 
 
 

--- a/recipes/asr/albanian/run.sh
+++ b/recipes/asr/albanian/run.sh
@@ -1,0 +1,251 @@
+
+
+# Copied from recipes/asr/librispeech/train-clean-100/
+
+if [ -z "${SPEECHAIN_ROOT}" ] || [ -z "${SPEECHAIN_PYTHON}" ];then
+  echo "Cannot find environmental variables SPEECHAIN_ROOT and SPEECHAIN_PYTHON.
+  Please move to the root path of the toolkit and run envir_preparation.sh there!"
+  exit 1
+fi
+recipe_run_root=${SPEECHAIN_ROOT}/recipes/run.sh
+
+# please manually change the following arguments everytime you dump a new dataset
+task=asr
+dataset=albanian
+subset=''
+
+
+function print_help_message {
+  echo "usage:
+  $0 \\ (The arguments in [] are optional while other arguments must be given)
+    [--dry_run false or true] \\                            # Whether to activate dry-running mode (default: false)
+    [--no_optim false or true] \\                           # Whether to activate no-optimization mode (default: false)
+    [--resume false or true] \\                             # Whether to activate resuming mode (default: false)
+    [--train_result_path TRAIN_RESULT_PATH] \\              # The value of train_result_path given to runner.py (default: none)
+    [--test_result_path TEST_RESULT_PATH] \\                # The value of train_result_path given to runner.py (default: none)
+    [--test_model TEST_MODEL] \\                            # The value of test_model given to runner.py (default: none)
+    --exp_cfg EXP_CFG \\                                    # The name of your specified configuration file in ${SPEECHAIN_ROOT}/recipes/${task}/${dataset}/${subset}/exp_cfg
+    [--data_cfg DATA_CFG] \\                                # The name of your specified configuration file in ${SPEECHAIN_ROOT}/recipes/${task}/${dataset}/${subset}/data_cfg (default: none)
+    [--infer_cfg INFER_CFG] \\                              # The name of your specified configuration file in ${SPEECHAIN_ROOT}/config/${task}/ (default: none)
+    [--train_num_workers TRAIN_NUM_WORKERS] \\              # The value of 'train_num_workers' given to runner.py (default: none)
+    [--valid_num_workers VALID_NUM_WORKERS] \\              # The value of 'valid_num_workers' given to runner.py (default: none)
+    [--test_num_workers TEST_NUM_WORKERS] \\                # The value of 'test_num_workers' given to runner.py (default: none)
+    [--accum_grad ACCUM_GRAD] \\                            # The value of 'accum_grad' given to runner.py (default: none)
+    [--ngpu NGPU] \\                                        # The value of 'ngpu' given to runner.py (default: none)
+    [--gpus GPUS] \\                                        # The value of 'gpus' given to runner.py (default: none)
+    --train TRAIN \\                                        # Whether to activate training mode (default: false)
+    --test TEST                                            # Whether to activate testing mode (default: false)" >&2
+  exit 1
+}
+
+
+# --- Arguments --- #
+dry_run=false
+no_optim=false
+
+resume=false
+train=true
+test=false
+train_result_path=
+test_result_path=
+test_model=
+
+exp_cfg=
+data_cfg=
+infer_cfg=
+
+train_num_workers=
+valid_num_workers=
+test_num_workers=
+accum_grad=
+ngpu=
+gpus=
+
+
+### get args from the command line ###
+while getopts ":h-:" optchar; do
+  case "${optchar}" in
+    -)
+      case "${OPTARG}" in
+        dry_run)
+          val="${!OPTIND}"; OPTIND=$(( OPTIND + 1 ))
+          dry_run=${val}
+          ;;
+        no_optim)
+          val="${!OPTIND}"; OPTIND=$(( OPTIND + 1 ))
+          no_optim=${val}
+          ;;
+        resume)
+          val="${!OPTIND}"; OPTIND=$(( OPTIND + 1 ))
+          resume=${val}
+          ;;
+        train)
+          val="${!OPTIND}"; OPTIND=$(( OPTIND + 1 ))
+          train=${val}
+          ;;
+        test)
+          val="${!OPTIND}"; OPTIND=$(( OPTIND + 1 ))
+          test=${val}
+          ;;
+        train_result_path)
+          val="${!OPTIND}"; OPTIND=$(( OPTIND + 1 ))
+          train_result_path=${val}
+          ;;
+        test_result_path)
+          val="${!OPTIND}"; OPTIND=$(( OPTIND + 1 ))
+          test_result_path=${val}
+          ;;
+        test_model)
+          val="${!OPTIND}"; OPTIND=$(( OPTIND + 1 ))
+          test_model=${val}
+          ;;
+        exp_cfg)
+          val="${!OPTIND}"; OPTIND=$(( OPTIND + 1 ))
+          exp_cfg=${val}
+          ;;
+        data_cfg)
+          val="${!OPTIND}"; OPTIND=$(( OPTIND + 1 ))
+          data_cfg=${val}
+          ;;
+        infer_cfg)
+          val="${!OPTIND}"; OPTIND=$(( OPTIND + 1 ))
+          infer_cfg=${val}
+          ;;
+        train_num_workers)
+          val="${!OPTIND}"; OPTIND=$(( OPTIND + 1 ))
+          train_num_workers=${val}
+          ;;
+        valid_num_workers)
+          val="${!OPTIND}"; OPTIND=$(( OPTIND + 1 ))
+          valid_num_workers=${val}
+          ;;
+        test_num_workers)
+          val="${!OPTIND}"; OPTIND=$(( OPTIND + 1 ))
+          test_num_workers=${val}
+          ;;
+        accum_grad)
+          val="${!OPTIND}"; OPTIND=$(( OPTIND + 1 ))
+          accum_grad=${val}
+          ;;
+        ngpu)
+          val="${!OPTIND}"; OPTIND=$(( OPTIND + 1 ))
+          ngpu=${val}
+          ;;
+        gpus)
+          val="${!OPTIND}"; OPTIND=$(( OPTIND + 1 ))
+          gpus=${val}
+          ;;
+        help)
+          print_help_message
+          ;;
+        ?)
+          echo "Unknown variable --$OPTARG"
+          exit 1
+          ;;
+      esac
+      ;;
+    h)
+      print_help_message
+      ;;
+    *)
+      echo "Please refer to an argument by '--'."
+      exit 1
+      ;;
+  esac
+done
+
+
+# --- 1. Argument Initialization --- #
+#
+args="
+  --task ${task} \
+  --dataset ${dataset} \
+  --dry_run ${dry_run} \
+  --no_optim ${no_optim} \
+  --resume ${resume} \
+  --train ${train} \
+  --test ${test}"
+
+#
+if [ -n "${subset}" ];then
+  args="${args} --subset ${subset}"
+fi
+
+#
+if [ -z ${exp_cfg} ];then
+   echo "Please give an experimental configuration by '--exp_cfg'!"
+   exit 1
+else
+  args="${args} --exp_cfg ${exp_cfg}"
+fi
+
+#
+if [ -n "${train_num_workers}" ];then
+  args="${args} --train_num_workers ${train_num_workers}"
+fi
+#
+if [ -n "${valid_num_workers}" ];then
+  args="${args} --valid_num_workers ${valid_num_workers}"
+fi
+#
+if [ -n "${test_num_workers}" ];then
+  args="${args} --test_num_workers ${test_num_workers}"
+fi
+#
+if [ -n "${accum_grad}" ];then
+  args="${args} --accum_grad ${accum_grad}"
+fi
+#
+if [ -n "${gpus}" ];then
+  args="${args} --gpus ${gpus}"
+fi
+#
+if [ -n "${ngpu}" ];then
+  args="${args} --ngpu ${ngpu}"
+fi
+
+#
+if [ -n "${data_cfg}" ];then
+  args="${args} --data_cfg ${data_cfg}"
+fi
+
+#
+if [ -n "${train_result_path}" ];then
+  args="${args} --train_result_path ${train_result_path}"
+fi
+
+#
+if ${test};then
+  #
+  if [ -n "${infer_cfg}" ];then
+    args="${args} --infer_cfg ${infer_cfg}"
+  fi
+  #
+  if [ -n "${test_result_path}" ];then
+    args="${args} --test_result_path ${test_result_path}"
+  fi
+  #
+  if [ -n "${test_model}" ];then
+    args="${args} --test_model ${test_model}"
+  fi
+fi
+
+
+# --- 2. Execute the Job --- #
+# ${args} should not be surrounded by double-quote
+# shellcheck disable=SC2086
+start_time=$(date +%s)
+
+bash "${recipe_run_root}" ${args}
+exit_status=$?
+if [ ${exit_status} -ne 0 ]; then
+  echo "The command 'bash \"${recipe_run_root}\" ${args}' failed to be executed and returns ${exit_status}!"
+  exit ${exit_status}
+fi
+
+end_time=$(date +%s)
+runtime=$((end_time - start_time))
+hours=$((runtime / 3600))
+minutes=$(( (runtime % 3600) / 60 ))
+seconds=$((runtime % 60))
+echo "Total runtime: $hours hours, $minutes minutes, $seconds seconds"

--- a/recipes/lm/albanian/wiki_char_lm_text/data_cfg/test_dev-clean.yaml
+++ b/recipes/lm/albanian/wiki_char_lm_text/data_cfg/test_dev-clean.yaml
@@ -1,0 +1,34 @@
+##############################################################################
+# Testing: dev-clean of LibriSpeech
+# Authors: Heli Qi
+# Description: This configuration is used to replace data_cfg in exp_cfg for tuning the inference hyperparamters on dev-clean of LibriSpeech
+# ############################################################################
+
+
+###################################
+# Experiment Parameters and setup #
+###################################
+# if your dumped dataset is outside the toolkit folder, please change dataset_path. There should be a folder named 'libritts' in dataset_path
+dataset_path: datasets/
+dataset: librispeech
+valid_dset: &valid_dset dev-clean
+
+wav_format: wav
+txt_format: no-punc
+
+
+
+##############################
+# Data Loading Configuration #
+##############################
+data_root: !ref <dataset_path>/<dataset>/data
+# Note: there must be a blank between the anchor '*valid_dset' and the colon ':'
+test:
+    *valid_dset :
+        type: abs.Iterator
+        conf:
+            dataset_type: speech_text.SpeechTextDataset
+            dataset_conf:
+                main_data:
+                    text: !ref <data_root>/<wav_format>/<valid_dset>/idx2<txt_format>_text
+            shuffle: False

--- a/recipes/lm/albanian/wiki_char_lm_text/exp_cfg/wiki_char_transformer.yaml
+++ b/recipes/lm/albanian/wiki_char_lm_text/exp_cfg/wiki_char_transformer.yaml
@@ -1,0 +1,138 @@
+###############################################################################
+# Model: Transformer Character LM
+# Language: Albanian
+# Training text: Wikipedia external text + oversampled Common Voice train text
+###############################################################################
+
+data_root: /home/ldap-users-2/veton-lu/data/albanian_asr
+lm_train_set: wiki300k_cvtrainx20
+valid_set: dev_full
+test_set: test_full
+
+txt_format: no-punc
+token_type: char
+token_num: char
+vocab_subset: train_full
+
+batch_len: 12000
+
+label_smoothing: 0.0
+length_normalized: true
+d_model: 256
+num_heads: 4
+fdfwd_dim: 1024
+enc_layer_num: 6
+dropout: 0.1
+
+warmup_steps: 4000
+
+seed: 0
+train_num_workers: 0
+valid_num_workers: 0
+pin_memory: False
+non_blocking: False
+
+accum_grad: 2
+ft_factor: 1.0
+grad_clip: 5.0
+
+ngpu: 1
+gpus: null
+
+train: True
+best_model_selection:
+  - !tuple (valid, text_ppl, min, 5)
+  - !tuple (valid, loss, min, 5)
+early_stopping_patience: 4
+num_epochs: 15
+
+visual_snapshot_number: 3
+visual_snapshot_interval: 5
+
+test: False
+test_model: 5_valid_text_ppl_average
+
+##############################
+# Data Loading Configuration #
+##############################
+
+data_cfg:
+  train:
+    type: block.BlockIterator
+    conf:
+      dataset_type: speech_text.SpeechTextDataset
+      dataset_conf:
+        main_data:
+          text: !ref <data_root>/lm_text/<lm_train_set>_lm_text
+      shuffle: True
+      is_descending: True
+      batch_len: !ref <batch_len>
+
+  valid:
+    type: abs.Iterator
+    conf:
+      dataset_type: speech_text.SpeechTextDataset
+      dataset_conf:
+        main_data:
+          text: !ref <data_root>/lm_text/<valid_set>_lm_text
+      shuffle: False
+
+  test:
+    test_full:
+      type: abs.Iterator
+      conf:
+        dataset_type: speech_text.SpeechTextDataset
+        dataset_conf:
+          main_data:
+            text: !ref <data_root>/lm_text/<test_set>_lm_text
+        shuffle: False
+
+####################################
+# Model Construction Configuration #
+####################################
+
+train_cfg:
+  model:
+    model_type: lm.LM
+
+    model_conf:
+      customize_conf:
+        token_type: !ref <token_type>
+        token_path: !ref <data_root>/<token_type>/<vocab_subset>/<token_num>/<txt_format>
+
+    module_conf:
+      emb:
+        type: embed
+        conf:
+          embedding_dim: !ref <d_model>
+
+      encoder:
+        type: transformer
+        conf:
+          posenc_dropout: !ref <dropout>
+          posenc_scale: false
+          emb_layernorm: true
+          emb_scale: false
+          d_model: !ref <d_model>
+          num_heads: !ref <num_heads>
+          num_layers: !ref <enc_layer_num>
+          att_dropout: !ref <dropout>
+          fdfwd_dim: !ref <fdfwd_dim>
+          fdfwd_dropout: !ref <dropout>
+          res_dropout: !ref <dropout>
+          layernorm_first: true
+
+    criterion_conf:
+      length_normalized: !ref <length_normalized>
+      label_smoothing: !ref <label_smoothing>
+
+  optim_sches:
+    type: noam.Noamlr
+    conf:
+      optim_type: Adam
+      optim_conf:
+        betas:
+          - 0.9
+          - 0.98
+        eps: 1.0e-9
+      warmup_steps: !ref <warmup_steps>

--- a/recipes/lm/albanian/wiki_char_lm_text/exp_cfg/wiki_char_transformer.yaml
+++ b/recipes/lm/albanian/wiki_char_lm_text/exp_cfg/wiki_char_transformer.yaml
@@ -4,7 +4,7 @@
 # Training text: Wikipedia external text + oversampled Common Voice train text
 ###############################################################################
 
-data_root: /home/ldap-users-2/veton-lu/data/albanian_asr
+data_root: datasets/albanian_asr
 lm_train_set: wiki300k_cvtrainx20
 valid_set: dev_full
 test_set: test_full

--- a/recipes/lm/albanian/wiki_char_lm_text/run.sh
+++ b/recipes/lm/albanian/wiki_char_lm_text/run.sh
@@ -1,0 +1,221 @@
+### Author: Heli Qi
+### Affiliation: NAIST
+### Date: 2022.12
+
+
+# --- Global References --- #
+if [ -z "${SPEECHAIN_ROOT}" ] || [ -z "${SPEECHAIN_PYTHON}" ];then
+  echo "Cannot find environmental variables SPEECHAIN_ROOT and SPEECHAIN_PYTHON.
+  Please move to the root path of the toolkit and run envir_preparation.sh there!"
+  exit 1
+fi
+recipe_run_root=${SPEECHAIN_ROOT}/recipes/run.sh
+
+# please manually change the following arguments everytime you dump a new dataset
+task=lm
+dataset=albanian
+subset='wiki_char_lm_text'
+
+
+function print_help_message {
+  echo "usage:
+  $0 \\ (The arguments in [] are optional while other arguments must be given)
+    [--dry_run false or true] \\                            # Whether to activate dry-running mode (default: false)
+    [--no_optim false or true] \\                           # Whether to activate no-optimization mode (default: false)
+    [--resume false or true] \\                             # Whether to activate resuming mode (default: false)
+    [--train_result_path TRAIN_RESULT_PATH] \\              # The value of train_result_path given to runner.py (default: none)
+    [--test_result_path TEST_RESULT_PATH] \\                # The value of train_result_path given to runner.py (default: none)
+    [--test_model TEST_MODEL] \\                            # The value of test_model given to runner.py (default: none)
+    --exp_cfg EXP_CFG \\                                    # The name of your specified configuration file in ${SPEECHAIN_ROOT}/recipes/${task}/${dataset}/${subset}/exp_cfg
+    [--data_cfg DATA_CFG] \\                                # The name of your specified configuration file in ${SPEECHAIN_ROOT}/recipes/${task}/${dataset}/${subset}/data_cfg (default: none)
+    [--infer_cfg INFER_CFG] \\                              # The name of your specified configuration file in ${SPEECHAIN_ROOT}/config/${task}/ (default: none)
+    [--num_workers NUM_WORKERS] \\                          # The value of 'num_workers' given to runner.py (default: none)
+    [--accum_grad ACCUM_GRAD] \\                            # The value of 'accum_grad' given to runner.py (default: none)
+    [--ngpu NGPU] \\                                        # The value of 'ngpu' given to runner.py (default: none)
+    [--gpus GPUS] \\                                        # The value of 'gpus' given to runner.py (default: none)
+    --train TRAIN \\                                        # Whether to activate training mode (default: true)
+    --test TEST                                            # Whether to activate testing mode (default: true)" >&2
+  exit 1
+}
+
+
+# --- Arguments --- #
+dry_run=false
+no_optim=false
+
+resume=false
+train=true
+test=true
+train_result_path=
+test_result_path=
+test_model=
+
+exp_cfg=
+data_cfg=
+infer_cfg=
+
+num_workers=
+accum_grad=
+ngpu=
+gpus=
+
+
+### get args from the command line ###
+while getopts ":h-:" optchar; do
+  case "${optchar}" in
+    -)
+      case "${OPTARG}" in
+        dry_run)
+          val="${!OPTIND}"; OPTIND=$(( OPTIND + 1 ))
+          dry_run=${val}
+          ;;
+        no_optim)
+          val="${!OPTIND}"; OPTIND=$(( OPTIND + 1 ))
+          no_optim=${val}
+          ;;
+        resume)
+          val="${!OPTIND}"; OPTIND=$(( OPTIND + 1 ))
+          resume=${val}
+          ;;
+        train)
+          val="${!OPTIND}"; OPTIND=$(( OPTIND + 1 ))
+          train=${val}
+          ;;
+        test)
+          val="${!OPTIND}"; OPTIND=$(( OPTIND + 1 ))
+          test=${val}
+          ;;
+        train_result_path)
+          val="${!OPTIND}"; OPTIND=$(( OPTIND + 1 ))
+          train_result_path=${val}
+          ;;
+        test_result_path)
+          val="${!OPTIND}"; OPTIND=$(( OPTIND + 1 ))
+          test_result_path=${val}
+          ;;
+        test_model)
+          val="${!OPTIND}"; OPTIND=$(( OPTIND + 1 ))
+          test_model=${val}
+          ;;
+        exp_cfg)
+          val="${!OPTIND}"; OPTIND=$(( OPTIND + 1 ))
+          exp_cfg=${val}
+          ;;
+        data_cfg)
+          val="${!OPTIND}"; OPTIND=$(( OPTIND + 1 ))
+          data_cfg=${val}
+          ;;
+        infer_cfg)
+          val="${!OPTIND}"; OPTIND=$(( OPTIND + 1 ))
+          infer_cfg=${val}
+          ;;
+        num_workers)
+          val="${!OPTIND}"; OPTIND=$(( OPTIND + 1 ))
+          num_workers=${val}
+          ;;
+        accum_grad)
+          val="${!OPTIND}"; OPTIND=$(( OPTIND + 1 ))
+          accum_grad=${val}
+          ;;
+        ngpu)
+          val="${!OPTIND}"; OPTIND=$(( OPTIND + 1 ))
+          ngpu=${val}
+          ;;
+        gpus)
+          val="${!OPTIND}"; OPTIND=$(( OPTIND + 1 ))
+          gpus=${val}
+          ;;
+        help)
+          print_help_message
+          ;;
+        *)
+          echo "Unknown variable --$OPTARG"
+          exit 1
+          ;;
+      esac
+      ;;
+    h)
+      print_help_message
+      ;;
+    *)
+      echo "Please refer to an argument by '--'."
+      exit 1
+      ;;
+  esac
+done
+
+
+# --- 1. Argument Initialization --- #
+#
+args="
+  --task ${task} \
+  --dataset ${dataset} \
+  --subset ${subset} \
+  --dry_run ${dry_run} \
+  --no_optim ${no_optim} \
+  --resume ${resume} \
+  --train ${train} \
+  --test ${test}"
+
+#
+if [ -z ${exp_cfg} ];then
+   echo "Please give an experimental configuration by '--exp_cfg'!"
+   exit 1
+else
+  args="${args} --exp_cfg ${exp_cfg}"
+fi
+
+#
+if [ -n "${num_workers}" ];then
+  args="${args} --num_workers ${num_workers}"
+fi
+#
+if [ -n "${accum_grad}" ];then
+  args="${args} --accum_grad ${accum_grad}"
+fi
+#
+if [ -n "${gpus}" ];then
+  args="${args} --gpus ${gpus}"
+fi
+#
+if [ -n "${ngpu}" ];then
+  args="${args} --ngpu ${ngpu}"
+fi
+
+#
+if [ -n "${data_cfg}" ];then
+  args="${args} --data_cfg ${data_cfg}"
+fi
+
+#
+if [ -n "${train_result_path}" ];then
+  args="${args} --train_result_path ${train_result_path}"
+fi
+
+#
+if ${test};then
+  #
+  if [ -n "${infer_cfg}" ];then
+    args="${args} --infer_cfg ${infer_cfg}"
+  fi
+  #
+  if [ -n "${test_result_path}" ];then
+    args="${args} --test_result_path ${test_result_path}"
+  fi
+  #
+  if [ -n "${test_model}" ];then
+    args="${args} --test_model ${test_model}"
+  fi
+fi
+
+
+# --- 2. Execute the Job --- #
+# ${args} should not be surrounded by double-quote
+# shellcheck disable=SC2086
+bash "${recipe_run_root}" ${args}
+if [ $? != 0 ];then
+  # ${args} should not be surrounded by double-quote
+  # shellcheck disable=SC2086
+  # shellcheck disable=SC1090
+  source "${recipe_run_root}" ${args}
+fi


### PR DESCRIPTION
This pull request adds a Speechain recipe for low-resource Albanian ASR.

Included changes:
- Added an Albanian ASR recipe under recipes/asr/albanian
- Added data configs for dev/test evaluation
- Added the final character-level ASR training configuration
- Added a README summarizing the setup, model architecture, training configuration, and final CER/WER results
- Added an external character-level Transformer LM recipe under recipes/lm/albanian/wiki_char_lm_text

No checkpoints, logs, experiment outputs, or audio files are included.

## Summary by Sourcery

Add Speechain recipes for Albanian ASR and an external Albanian character-level language model, including configs, run scripts, and documentation of experimental results.

New Features:
- Introduce an Albanian ASR recipe with a configurable training and inference run script.
- Add an Albanian character-level Transformer LM recipe based on Wikipedia and Common Voice text.
- Provide experiment configuration files for Albanian ASR and the external character LM, including decoding sweeps and data loading setups.

Documentation:
- Document the Albanian ASR setup, model architecture, training configuration, decoding strategy, and final CER/WER results in a new README.